### PR TITLE
Add option validation

### DIFF
--- a/lib/accomplice.ex
+++ b/lib/accomplice.ex
@@ -42,15 +42,21 @@ defmodule Accomplice do
   ## Examples:
       iex> constraints = %{minimum: 2, ideal: 3, maximum: 4}
       iex> group(['a', 'b', 'c', 'd', 'e', 'f'], constraints)
-      [['f', 'e', 'd'], ['c', 'b', 'f']]
+      [['f', 'e', 'd'], ['c', 'b', 'a']]
   """
   @spec group(list(any()), map()) :: list(any()) | :impossible
   def group([], _options), do: []
   def group(elements, %{minimum: _, ideal: _, maximum: _} = options) do
-    group([], elements, options)
+    case options |> validate_options do
+      {:error, message} -> {:error, message}
+      options -> group([], elements, options)
+    end
   end
   def group(elements, options) do
-    group_simple([], elements, options)
+    case options |> validate_options do
+      {:error, message} -> {:error, message}
+      options -> group_simple([], elements, options)
+    end
   end
 
   @doc """

--- a/lib/accomplice_helpers.ex
+++ b/lib/accomplice_helpers.ex
@@ -2,6 +2,26 @@ defmodule Accomplice.Helpers do
   @moduledoc false
 
   @doc false
+  @spec validate_options(map()) :: map() | {:error, atom()}
+  def validate_options(%{minimum: min, ideal: ideal, maximum: max} = options) do
+    cond do
+      min < 1 || max < 1 || ideal < 1 -> {:error, :size_constraint_below_one}
+      min > max                       -> {:error, :minimum_above_maximum}
+      ideal < min || ideal > max      -> {:error, :ideal_not_between_min_and_max}
+      true                            -> options
+    end
+  end
+  def validate_options(%{minimum: min, maximum: max} = options) do
+    cond do
+      min < 1 || max < 1 -> {:error, :size_constraint_below_one}
+      min > max          -> {:error, :minimum_above_maximum}
+      true               -> options
+    end
+  end
+  def validate_options(options) when is_map(options), do: {:error, :missing_size_constraint}
+  def validate_options(_), do: {:error, :options_is_not_map}
+
+  @doc false
   @spec pop(list(any())) :: {any(), list(any())} | {nil, list(any())}
   def pop([]), do: {nil, []}
   def pop([head | tail]), do: {head, tail}
@@ -43,5 +63,4 @@ defmodule Accomplice.Helpers do
   defp add_actions(ungrouped) do
     for _ <- 1..length(ungrouped), do: :add
   end
-
 end

--- a/test/accomplice_helpers_test.exs
+++ b/test/accomplice_helpers_test.exs
@@ -1,9 +1,42 @@
-defmodule AccompliceHelpersTest do 
+defmodule AccompliceHelpersTest do
   use ExUnit.Case
   use Quixir
 
   alias Accomplice.Helpers
   import OrderInvariantCompare # for <~> operator
+
+  describe "validate_options/1" do
+    test "options must be map" do
+      assert {:error, :options_is_not_map} == Helpers.validate_options([])
+      assert {:error, :options_is_not_map} == Helpers.validate_options(nil)
+      assert {:error, :options_is_not_map} == Helpers.validate_options("")
+    end
+
+    test "missing size constraints is invalid" do
+      assert {:error, :missing_size_constraint} == Helpers.validate_options(%{})
+      assert {:error, :missing_size_constraint} == Helpers.validate_options(%{minimum: 1})
+      assert {:error, :missing_size_constraint} == Helpers.validate_options(%{maximum: 1})
+    end
+
+    test "size constraints must be greater than zero" do
+      assert {:error, :size_constraint_below_one} == Helpers.validate_options(%{minimum: 0, maximum: 1})
+      assert {:error, :size_constraint_below_one} == Helpers.validate_options(%{minimum: 1, maximum: 0})
+      assert {:error, :size_constraint_below_one} == Helpers.validate_options(%{minimum: 1, ideal: 0, maximum: 1})
+      assert {:error, :size_constraint_below_one} == Helpers.validate_options(%{minimum: 1, ideal: 1, maximum: 0})
+      assert {:error, :size_constraint_below_one} == Helpers.validate_options(%{minimum: 0, ideal: 1, maximum: 1})
+      assert %{} = Helpers.validate_options(%{minimum: 1, maximum: 1})
+      assert %{} = Helpers.validate_options(%{minimum: 1, ideal: 1, maximum: 1})
+    end
+
+    test "min cannot be greater than max" do
+      assert {:error, :minimum_above_maximum} == Helpers.validate_options(%{minimum: 2, maximum: 1})
+    end
+
+    test "ideal must be between min and max" do
+      assert {:error, :ideal_not_between_min_and_max} == Helpers.validate_options(%{minimum: 2, ideal: 1, maximum: 3})
+      assert {:error, :ideal_not_between_min_and_max} == Helpers.validate_options(%{minimum: 2, ideal: 4, maximum: 3})
+    end
+  end
 
   describe "pop/1" do
     test "returns the head and tail if the list contains elements" do


### PR DESCRIPTION
Adds validation of options. If the options are not valid, then the group functions return error tuples of the form `{:error, message}` instead of a grouping.