### PR TITLE
Add memoization to grouping

### DIFF
--- a/lib/accomplice_helpers.ex
+++ b/lib/accomplice_helpers.ex
@@ -67,6 +67,6 @@ defmodule Accomplice.Helpers do
   @doc false
   @spec generate_memo_key(list(any()), list(any())) :: String.t
   def generate_memo_key(current_group, ungrouped) do
-    "#{inspect current_group}|#{inspect ungrouped}"
+    "#{inspect Enum.sort(current_group)}|#{inspect Enum.sort(ungrouped)}"
   end
 end

--- a/lib/accomplice_helpers.ex
+++ b/lib/accomplice_helpers.ex
@@ -63,4 +63,10 @@ defmodule Accomplice.Helpers do
   defp add_actions(ungrouped) do
     for _ <- 1..length(ungrouped), do: :add
   end
+
+  @doc false
+  @spec generate_memo_key(list(any()), list(any())) :: String.t
+  def generate_memo_key(current_group, ungrouped) do
+    "#{inspect current_group}|#{inspect ungrouped}"
+  end
 end

--- a/lib/accomplice_helpers.ex
+++ b/lib/accomplice_helpers.ex
@@ -67,6 +67,16 @@ defmodule Accomplice.Helpers do
   @doc false
   @spec generate_memo_key(list(any()), list(any())) :: String.t
   def generate_memo_key(current_group, ungrouped) do
-    "#{inspect Enum.sort(current_group)}|#{inspect Enum.sort(ungrouped)}"
+    current_group_string = convert_list_to_string(current_group)
+    ungrouped_string     = convert_list_to_string(ungrouped)
+    "[#{current_group_string}][#{ungrouped_string}]"
+  end
+
+  @spec convert_list_to_string(list(any())) :: String.t
+  defp convert_list_to_string(list) when is_list(list) do
+    list
+    |> Enum.sort
+    |> Enum.map(&(inspect &1))
+    |> Enum.join(",")
   end
 end

--- a/test/accomplice_helpers_test.exs
+++ b/test/accomplice_helpers_test.exs
@@ -96,4 +96,12 @@ defmodule AccompliceHelpersTest do
       end
     end
   end
+  describe "generate_memo_key/2" do
+    test "returns a string representing the passed in data" do
+      ptest [current_group: list(of: any(), max: 10), ungrouped: list(of: any(), max: 10)], repeat_for: 30 do
+        memo_key = Helpers.generate_memo_key(current_group, ungrouped)
+        assert memo_key |> String.contains?("|")
+      end
+    end
+  end
 end

--- a/test/accomplice_helpers_test.exs
+++ b/test/accomplice_helpers_test.exs
@@ -100,7 +100,6 @@ defmodule AccompliceHelpersTest do
     test "returns a string representing the passed in data" do
       ptest [current_group: list(of: any(), max: 10), ungrouped: list(of: any(), max: 10)], repeat_for: 30 do
         memo_key = Helpers.generate_memo_key(current_group, ungrouped)
-        assert memo_key |> String.contains?("|")
       end
     end
 

--- a/test/accomplice_helpers_test.exs
+++ b/test/accomplice_helpers_test.exs
@@ -103,5 +103,11 @@ defmodule AccompliceHelpersTest do
         assert memo_key |> String.contains?("|")
       end
     end
+
+    test "returns the same memo_key even if elements are in different orders" do
+      assert Helpers.generate_memo_key([1,2,3,4], [5,6,7,8]) ==
+             Helpers.generate_memo_key([3,2,1,4], [8,5,7,6])
+
+    end
   end
 end


### PR DESCRIPTION
Adds memoization to the grouping function when an ideal parameter is supplied, so that the algorithm doesn't unnecessarily recompute groupings that it has already computed. This is a significant performance increase for groupings of large numbers of elements, when significant backtracking must occur, such as when there is no grouping that can satisfy the constraints.