### PR TITLE
Remove redundant actions

### DIFF
--- a/lib/accomplice_helpers.ex
+++ b/lib/accomplice_helpers.ex
@@ -30,17 +30,21 @@ defmodule Accomplice.Helpers do
 
   @doc false
   @spec create_actions(list(list(any())), list(any()), map()) :: actions
+  def create_actions(current_group, [], %{minimum: minimum, ideal: ideal, maximum: maximum}) do
+    current_group_length = length(current_group)
+    if current_group_length < minimum do
+      :impossible
+    else
+      [:complete]
+    end
+  end
   def create_actions(current_group, ungrouped, %{minimum: minimum, ideal: ideal, maximum: maximum}) do
     current_group_length = length(current_group)
     cond do
       current_group_length < minimum ->
         # when the current_group's length is less than the minimum constraint,
-        # our only option is to add en element. If there are no elements to add,
-        # then we have no legal action and so return the :impossible atom
-        case ungrouped do
-          []        -> :impossible
-          ungrouped -> [:add]
-        end
+        # our only option is to add en element.
+        [:add]
       current_group_length == maximum ->
         # when the current_group's length is equal to the maximum constraint,
         # our only option is to complete the group.
@@ -50,19 +54,12 @@ defmodule Accomplice.Helpers do
         # to try adding an element if there are any to add, then we'll try
         # completing the group since we know that we're at least at the minimum
         # length.
-        case ungrouped do
-          []        -> [:complete]
-          ungrouped -> [:add, :complete]
-        end
+        [:add, :complete]
       current_group_length == ideal ->
         # when the current group's length is at ideal, we first want to try
-        # completing the group, then try adding the elements if there are any
-        # to add, since we know that we're below the maximum current_group
-        # length.
-        case ungrouped do
-          []        -> [:complete]
-          ungrouped -> [:complete, :add]
-        end
+        # completing the group, then try adding an element, since we know that
+        # we're below the maximum current_group length.
+        [:complete, :add]
     end
   end
 

--- a/lib/accomplice_helpers.ex
+++ b/lib/accomplice_helpers.ex
@@ -39,7 +39,7 @@ defmodule Accomplice.Helpers do
         # then we have no legal action and so return the :impossible atom
         case ungrouped do
           []        -> :impossible
-          ungrouped -> add_actions(ungrouped)
+          ungrouped -> [:add]
         end
       current_group_length == maximum ->
         # when the current_group's length is equal to the maximum constraint,
@@ -47,21 +47,23 @@ defmodule Accomplice.Helpers do
         [:complete]
       current_group_length < ideal ->
         # when the current group's length is less than the ideal, we first want
-        # to try adding an element, then we'll try completing the group since we
-        # know that we're at least at the minimum length.
-        add_actions(ungrouped) ++ [:complete]
+        # to try adding an element if there are any to add, then we'll try
+        # completing the group since we know that we're at least at the minimum
+        # length.
+        case ungrouped do
+          []        -> [:complete]
+          ungrouped -> [:add, :complete]
+        end
       current_group_length == ideal ->
-        # when the current group's length is at ideal, we first want to try completing
-        # the group, then try adding the elements, since we know that we're below the
-        # maximum current_group length.
-        [:complete | add_actions(ungrouped)]
+        # when the current group's length is at ideal, we first want to try
+        # completing the group, then try adding the elements if there are any
+        # to add, since we know that we're below the maximum current_group
+        # length.
+        case ungrouped do
+          []        -> [:complete]
+          ungrouped -> [:complete, :add]
+        end
     end
-  end
-
-  @spec add_actions(list(any())) :: list({:add, any()})
-  defp add_actions([]), do: []
-  defp add_actions(ungrouped) do
-    for _ <- 1..length(ungrouped), do: :add
   end
 
   @doc false

--- a/test/accomplice_helpers_test.exs
+++ b/test/accomplice_helpers_test.exs
@@ -3,7 +3,6 @@ defmodule AccompliceHelpersTest do
   use Quixir
 
   alias Accomplice.Helpers
-  import OrderInvariantCompare # for <~> operator
 
   describe "validate_options/1" do
     test "options must be map" do
@@ -64,7 +63,7 @@ defmodule AccompliceHelpersTest do
       assert [:add] == Helpers.create_actions([], [1], %{minimum: 1, ideal: 1, maximum: 1})
       assert [:add] == Helpers.create_actions([], [1], %{minimum: 2, ideal: 2, maximum: 2})
       assert [:add] == Helpers.create_actions([1], [2], %{minimum: 2, ideal: 2, maximum: 2})
-      assert [:add, :add] <~> Helpers.create_actions([], [1, 2], %{minimum: 1, ideal: 1, maximum: 1})
+      assert [:add] == Helpers.create_actions([], [1, 2], %{minimum: 1, ideal: 1, maximum: 1})
     end
 
     test "when the current_group is at the maximum constraint, only action is to complete the group" do
@@ -86,8 +85,7 @@ defmodule AccompliceHelpersTest do
       assert [:complete, :add] == Helpers.create_actions([1, 2, 3], [4], %{minimum: 2, ideal: 3, maximum: 4})
       assert [:complete, :add] == Helpers.create_actions([1, 2, 3], [4], %{minimum: 3, ideal: 3, maximum: 4})
 
-      assert [:complete | add_actions] = Helpers.create_actions([1], [2, 3, 4], %{minimum: 1, ideal: 1, maximum: 2})
-      assert add_actions <~> [:add, :add, :add]
+      assert [:complete, :add] = Helpers.create_actions([1], [2, 3, 4], %{minimum: 1, ideal: 1, maximum: 2})
     end
 
     test "there are no invalid inputs" do
@@ -99,14 +97,13 @@ defmodule AccompliceHelpersTest do
   describe "generate_memo_key/2" do
     test "returns a string representing the passed in data" do
       ptest [current_group: list(of: any(), max: 10), ungrouped: list(of: any(), max: 10)], repeat_for: 30 do
-        memo_key = Helpers.generate_memo_key(current_group, ungrouped)
+        Helpers.generate_memo_key(current_group, ungrouped)
       end
     end
 
     test "returns the same memo_key even if elements are in different orders" do
       assert Helpers.generate_memo_key([1,2,3,4], [5,6,7,8]) ==
              Helpers.generate_memo_key([3,2,1,4], [8,5,7,6])
-
     end
   end
 end


### PR DESCRIPTION
When deciding the list of actions to try next, we don't need to try to add multiple times, if the elements we are trying to add are equally able to succeed or fail.