### PR TITLE
Simplify easy cases

### DIFF
--- a/lib/accomplice.ex
+++ b/lib/accomplice.ex
@@ -46,14 +46,27 @@ defmodule Accomplice do
   """
   @spec group(list(any()), map()) :: list(any()) | :impossible | {:error, atom()}
   def group([], _options), do: []
-  def group(elements, %{minimum: _, ideal: _, maximum: _} = options) do
-    validate_options(options)
-    {grouping, _memo} = group(elements, [], options, %{})
-    grouping
-  end
-  def group(elements, options) do
+  def group(elements, %{minimum: _, ideal: same, maximum: same} = options) do
     validate_options(options)
     group_simple(elements, [], options)
+  end
+  def group(elements, %{minimum: min, ideal: _, maximum: _} = options) do
+    validate_options(options)
+    number_of_elements = length(elements)
+    cond do
+      number_of_elements < min -> :impossible
+      true ->
+        {grouping, _memo} = group(elements, [], options, %{})
+        grouping
+    end
+  end
+  def group(elements, %{minimum: min, maximum: _} = options) do
+    validate_options(options)
+    number_of_elements = length(elements)
+    cond do
+      number_of_elements < min -> :impossible
+      true -> group_simple(elements, [], options)
+    end
   end
 
   @doc """

--- a/lib/accomplice.ex
+++ b/lib/accomplice.ex
@@ -47,18 +47,13 @@ defmodule Accomplice do
   @spec group(list(any()), map()) :: list(any()) | :impossible | {:error, atom()}
   def group([], _options), do: []
   def group(elements, %{minimum: _, ideal: _, maximum: _} = options) do
-    case options |> validate_options do
-      {:error, message} -> {:error, message}
-      options ->
-        {grouping, _memo} = group(elements, [], options, %{})
-        grouping
-    end
+    validate_options(options)
+    {grouping, _memo} = group(elements, [], options, %{})
+    grouping
   end
   def group(elements, options) do
-    case options |> validate_options do
-      {:error, message} -> {:error, message}
-      options -> group_simple(elements, [], options)
-    end
+    validate_options(options)
+    group_simple(elements, [], options)
   end
 
   @doc """

--- a/test/accomplice_helpers_test.exs
+++ b/test/accomplice_helpers_test.exs
@@ -6,34 +6,34 @@ defmodule AccompliceHelpersTest do
 
   describe "validate_options/1" do
     test "options must be map" do
-      assert {:error, :options_is_not_map} == Helpers.validate_options([])
-      assert {:error, :options_is_not_map} == Helpers.validate_options(nil)
-      assert {:error, :options_is_not_map} == Helpers.validate_options("")
+      assert_raise ArgumentError, fn -> Helpers.validate_options([]) end
+      assert_raise ArgumentError, fn -> Helpers.validate_options(nil) end
+      assert_raise ArgumentError, fn -> Helpers.validate_options("") end
     end
 
     test "missing size constraints is invalid" do
-      assert {:error, :missing_size_constraint} == Helpers.validate_options(%{})
-      assert {:error, :missing_size_constraint} == Helpers.validate_options(%{minimum: 1})
-      assert {:error, :missing_size_constraint} == Helpers.validate_options(%{maximum: 1})
+      assert_raise ArgumentError, fn -> Helpers.validate_options(%{}) end
+      assert_raise ArgumentError, fn -> Helpers.validate_options(%{minimum: 1}) end
+      assert_raise ArgumentError, fn -> Helpers.validate_options(%{maximum: 1}) end
     end
 
     test "size constraints must be greater than zero" do
-      assert {:error, :size_constraint_below_one} == Helpers.validate_options(%{minimum: 0, maximum: 1})
-      assert {:error, :size_constraint_below_one} == Helpers.validate_options(%{minimum: 1, maximum: 0})
-      assert {:error, :size_constraint_below_one} == Helpers.validate_options(%{minimum: 1, ideal: 0, maximum: 1})
-      assert {:error, :size_constraint_below_one} == Helpers.validate_options(%{minimum: 1, ideal: 1, maximum: 0})
-      assert {:error, :size_constraint_below_one} == Helpers.validate_options(%{minimum: 0, ideal: 1, maximum: 1})
+      assert_raise ArgumentError, fn -> Helpers.validate_options(%{minimum: 0, maximum: 1}) end
+      assert_raise ArgumentError, fn -> Helpers.validate_options(%{minimum: 1, maximum: 0}) end
+      assert_raise ArgumentError, fn -> Helpers.validate_options(%{minimum: 1, ideal: 0, maximum: 1}) end
+      assert_raise ArgumentError, fn -> Helpers.validate_options(%{minimum: 1, ideal: 1, maximum: 0}) end
+      assert_raise ArgumentError, fn -> Helpers.validate_options(%{minimum: 0, ideal: 1, maximum: 1}) end
       assert %{} = Helpers.validate_options(%{minimum: 1, maximum: 1})
       assert %{} = Helpers.validate_options(%{minimum: 1, ideal: 1, maximum: 1})
     end
 
     test "min cannot be greater than max" do
-      assert {:error, :minimum_above_maximum} == Helpers.validate_options(%{minimum: 2, maximum: 1})
+      assert_raise ArgumentError, fn -> Helpers.validate_options(%{minimum: 2, maximum: 1}) end
     end
 
     test "ideal must be between min and max" do
-      assert {:error, :ideal_not_between_min_and_max} == Helpers.validate_options(%{minimum: 2, ideal: 1, maximum: 3})
-      assert {:error, :ideal_not_between_min_and_max} == Helpers.validate_options(%{minimum: 2, ideal: 4, maximum: 3})
+      assert_raise ArgumentError, fn -> Helpers.validate_options(%{minimum: 2, ideal: 1, maximum: 3}) end
+      assert_raise ArgumentError, fn -> Helpers.validate_options(%{minimum: 2, ideal: 4, maximum: 3}) end
     end
   end
 


### PR DESCRIPTION
Make constraint validation failures raise Argument errors rather than return `{:error, reason}` tuples. This simplifies the code that is calling validation, and also makes more sense. If the constraints are incorrect, we should fail immediately and hard.

Make the case where the minimum constraint is greater than the length of the list of elements to be grouped return `:impossible` immediately, rather than exhaustively search when we already know it will never succeed.